### PR TITLE
Do try_sudo for `npm install`, not `cd`

### DIFF
--- a/lib/capistrano/npm.rb
+++ b/lib/capistrano/npm.rb
@@ -7,7 +7,7 @@ Capistrano::Configuration.instance(true).load do
   namespace :npm do
     desc 'Runs npm install.'
     task :install, :roles => :app, :except => { :no_release => true } do
-      try_sudo "cd #{latest_release} && #{npm_path} #{npm_options} install"
+      run "cd #{latest_release} && #{try_sudo} #{npm_path} #{npm_options} install"
     end
   end
 end


### PR DESCRIPTION
Because if an user is using `sudo`, npm:install will run
`sudo cd ... && npm ...`, and fails.
