### PR TITLE
Use lambda for npm_target_path option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or can be run in isolation with `cap production npm:install`
 Configurable options:
 
 ```ruby
-set :npm_target_path, release_path.join('subdir') # default not set
+set :npm_target_path, -> { release_path.join('subdir') } # default not set
 set :npm_flags, '--production --silent'           # default
 set :npm_roles, :all                              # default
 ```


### PR DESCRIPTION
Otherwise, `npm_target_path` is always set to current directory, and does not run `npm install` in the in-progress released directory. Plus, it's in line with how bundler plugin does it: https://github.com/capistrano/bundler
