### PR TITLE
Added npm:rebuild task.

### DIFF
--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -42,6 +42,22 @@ namespace :npm do
       end
     end
   end
+
+  desc <<-DESC
+        Rebuild via npm. This command is executed within the same context \
+        as npm install using the npm_roles and npm_target_path \
+        variables.
+
+        This task is strictly opt-in. The main reason you'll want to run this \
+        would be after changing npm versions on the server.
+    DESC
+  task :rebuild do
+    on roles fetch(:npm_roles) do
+      within fetch(:npm_target_path, release_path) do
+        execute :npm, 'rebuild'
+      end
+    end
+  end
 end
 
 namespace :load do


### PR DESCRIPTION
One more useful task to add.  `npm rebuild` is used primarily after the node version on the server changes.  Typically this is run via whatever configuration management tool you're leveraging, but it's nice to have easy access to it via cap as well.
