### PR TITLE
add --no-spin as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Configurable options:
 
 ```ruby
 set :npm_target_path, -> { release_path.join('subdir') } # default not set
-set :npm_flags, '--production --silent'           # default
+set :npm_flags, '--production --silent --no-spin' # default
 set :npm_roles, :all                              # default
 ```
 
 ### Dependencies
 
-npm allows for normal `dependencies` and `devDependencies`. By default this gem uses `'--production --silent'` as the install flags which will **only** install `dependencies` and skip `devDependencies`. If you want your `devDependencies` installed as well, then remove '--production`.
+npm allows for normal `dependencies` and `devDependencies`. By default this gem uses `'--production --silent --no-spin'` as the install flags which will **only** install `dependencies` and skip `devDependencies`. If you want your `devDependencies` installed as well, then remove '--production`.
 
 ## Contributing
 

--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -2,12 +2,12 @@ namespace :npm do
   desc <<-DESC
         Install the project dependencies via npm. By default, devDependencies \
         will not be installed. The install command is executed \
-        with the --production and --silent flags.
+        with the --production, --silent and --no-spin flags.
 
         You can override any of these defaults by setting the variables shown below.
 
           set :npm_target_path, nil
-          set :npm_flags, '--production --silent'
+          set :npm_flags, '--production --silent --no-spin'
           set :npm_roles, :all
     DESC
   task :install do
@@ -62,7 +62,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :npm_flags, '--production --silent'
+    set :npm_flags, %w(--production --silent --no-spin)
     set :npm_prune_flags, '--production'
     set :npm_roles, :all
   end


### PR DESCRIPTION
When I deployed with debug my terminal was flooded with:
DEBUG[43b1a695]     /[0G
DEBUG[43b1a695]     -[0G
DEBUG[43b1a695]     [0G
DEBUG[43b1a695]     |[0G
DEBUG[43b1a695]     /[0G
DEBUG[43b1a695]     -[0G
