### PR TITLE
Refer npm_env_variables while running npm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Configurable options:
 set :npm_target_path, -> { release_path.join('subdir') } # default not set
 set :npm_flags, '--production --silent --no-spin' # default
 set :npm_roles, :all                              # default
+set :npm_env_variables, {}                        # default
 ```
 
 ### Dependencies

--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -9,11 +9,14 @@ namespace :npm do
           set :npm_target_path, nil
           set :npm_flags, '--production --silent --no-spin'
           set :npm_roles, :all
+          set :npm_env_variables, {}
     DESC
   task :install do
     on roles fetch(:npm_roles) do
       within fetch(:npm_target_path, release_path) do
-        execute :npm, 'install', fetch(:npm_flags)
+        with fetch(:npm_env_variables, {}) do
+          execute :npm, 'install', fetch(:npm_flags)
+        end
       end
     end
   end
@@ -54,7 +57,9 @@ namespace :npm do
   task :rebuild do
     on roles fetch(:npm_roles) do
       within fetch(:npm_target_path, release_path) do
-        execute :npm, 'rebuild'
+        with fetch(:npm_env_variables, {}) do
+          execute :npm, 'rebuild'
+        end
       end
     end
   end


### PR DESCRIPTION
Hi, I've added `npm_env_variables` to set environment variables when running `npm install`, as it can be needed for some private network setups.

You can refer [capistrano-bundler](https://github.com/capistrano/bundler) which also has `bundler_env_variables` support.
