### PR TITLE
Update npm install command flag

### DIFF
--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -67,7 +67,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :npm_flags, %w(--production --silent --no-spin)
+    set :npm_flags, %w(--production --silent --no-progress)
     set :npm_prune_flags, '--production'
     set :npm_roles, :all
   end


### PR DESCRIPTION
Update npm install command flags to use the new flag for not displaying the npm loading bar when running `npm install` as per https://github.com/npm/npm/issues/8704

I am having issues with the output as the old `no-spin` flag no longer works