### PR TITLE
Add `:npm_method` variable to allow for `npm ci` installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ set :npm_target_path, -> { release_path.join('subdir') } # default not set
 set :npm_flags, '--production --silent --no-progress'    # default
 set :npm_roles, :all                                     # default
 set :npm_env_variables, {}                               # default
+set :npm_method, 'install'                               # default 
 ```
+
+### NPM Method
+As of version 5.7.0 of npm, a new install method (`ci`) was introduced which utilises
+the `package-lock.json` file. Change `npm_method` to `ci` in order to use make
+use of the improved installation method.
 
 ### Dependencies
 

--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -10,12 +10,13 @@ namespace :npm do
           set :npm_flags, '--production --silent --no-spin'
           set :npm_roles, :all
           set :npm_env_variables, {}
+          set :npm_method, 'install'
     DESC
   task :install do
     on roles fetch(:npm_roles) do
       within fetch(:npm_target_path, release_path) do
         with fetch(:npm_env_variables, {}) do
-          execute :npm, 'install', fetch(:npm_flags)
+          execute :npm, fetch(:npm_method), fetch(:npm_flags)
         end
       end
     end
@@ -70,5 +71,6 @@ namespace :load do
     set :npm_flags, %w(--production --silent --no-progress)
     set :npm_prune_flags, '--production'
     set :npm_roles, :all
+    set :npm_method, 'install'
   end
 end


### PR DESCRIPTION
Update of PR #23 to implement @swalkinshaw suggested change for setting the default value for `npm_method`.