### PR TITLE
Feature/require without hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ set :npm_roles, :all                                     # default
 set :npm_env_variables, {}                               # default
 ```
 
+Alternatively, if you want to have control on the execution of npm tasks
+
+```ruby
+# Capfile
+require capistrano/npm/without_hooks
+```
+
+You can then add the hooks on a per deploy script basis
+
+```ruby
+# config/deploy/my_stage_with_npm.rb
+before 'deploy:updated', 'npm:install'
+```
+
 ### Dependencies
 
 npm allows for normal `dependencies` and `devDependencies`. By default this gem uses `'--production --silent --no-progress'` as the install flags which will **only** install `dependencies` and skip `devDependencies`. If you want your `devDependencies` installed as well, then remove `--production`.

--- a/capistrano-npm.gemspec
+++ b/capistrano-npm.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'capistrano-npm'
-  spec.version       = '1.0.2'
+  spec.version       = '1.1.0'
   spec.authors       = ['Scott Walkinshaw']
   spec.email         = ['scott.walkinshaw@gmail.com']
   spec.description   = %q{npm support for Capistrano 3.x}

--- a/lib/capistrano/hooks/npm.rb
+++ b/lib/capistrano/hooks/npm.rb
@@ -1,0 +1,1 @@
+before 'deploy:updated', 'npm:install'

--- a/lib/capistrano/npm.rb
+++ b/lib/capistrano/npm.rb
@@ -1,1 +1,1 @@
-load File.expand_path('../tasks/npm.rake', __FILE__)
+load File.expand_path('../tasks/deploy_npm.rake', __FILE__)

--- a/lib/capistrano/npm/without_hooks.rb
+++ b/lib/capistrano/npm/without_hooks.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/npm.rake', __FILE__)

--- a/lib/capistrano/tasks/deploy_npm.rake
+++ b/lib/capistrano/tasks/deploy_npm.rake
@@ -1,2 +1,2 @@
 load File.expand_path('../npm.rake', __FILE__)
-load File.expand_path('../../hooks/nvm_hooks.rake', __FILE__)
+load File.expand_path('../../hooks/nvm.rake', __FILE__)

--- a/lib/capistrano/tasks/deploy_npm.rake
+++ b/lib/capistrano/tasks/deploy_npm.rake
@@ -1,2 +1,2 @@
 load File.expand_path('../npm.rake', __FILE__)
-load File.expand_path('../../hooks/nvm.rake', __FILE__)
+load File.expand_path('../../hooks/npm.rake', __FILE__)

--- a/lib/capistrano/tasks/deploy_npm.rake
+++ b/lib/capistrano/tasks/deploy_npm.rake
@@ -1,0 +1,2 @@
+load File.expand_path('../npm.rake', __FILE__)
+load File.expand_path('../../hooks/nvm_hooks.rake', __FILE__)


### PR DESCRIPTION
Allows to load the gem but specify per deployment stage if we want to run hooks or not. Inspired from capistrano passenger
```ruby
gem 'capistrano-npm',
    git: 'https://github.com/Startouf/npm',
    branch: 'feature/require-without-hooks',
    require: false
```